### PR TITLE
WSOD without checkout module.

### DIFF
--- a/commerce_btcpay.info.yml
+++ b/commerce_btcpay.info.yml
@@ -5,4 +5,5 @@ package: Commerce
 core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
+  - commerce:commerce_checkout
   - commerce:commerce_payment


### PR DESCRIPTION
Hey so this is installed now thank you.

When hitting `admin/commerce/config/payment-gateways/add` (as per the instructions) unless one has enabled `commerce_checkout` we get an unexpected error.